### PR TITLE
Fixed minor point in bootstrap variables for header fonts

### DIFF
--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -5,7 +5,7 @@
 
 // General style
 $font-family-sans-serif:  $body-font;
-$headings-font-family:    $headers-font;
+$headings-font-family:    $body-font;
 $body-bg:                 $light-gray;
 $font-size-base: 1rem;
 


### PR DESCRIPTION
The headers were coming up as Amaranth, so I fixed these to also be Lato in the Bootstrap variables. Please review and merge.